### PR TITLE
SensitivePhoneNumbers: Fix number comparison

### DIFF
--- a/src/com/android/server/telecom/SensitivePhoneNumbers.java
+++ b/src/com/android/server/telecom/SensitivePhoneNumbers.java
@@ -19,6 +19,7 @@ package com.android.server.telecom;
 
 import android.content.Context;
 import android.os.Environment;
+import android.telephony.PhoneNumberUtils;
 import android.telephony.SubscriptionManager;
 import android.telephony.TelephonyManager;
 import android.text.TextUtils;
@@ -111,8 +112,13 @@ public class SensitivePhoneNumbers {
         String networkUsed = telephonyManager.getNetworkOperator(subIdInt);
         if (!TextUtils.isEmpty(networkUsed)) {
             String networkMCC = networkUsed.substring(0, 3);
-            return mSensitiveNumbersMap.containsKey(networkMCC) &&
-                   mSensitiveNumbersMap.get(networkMCC).contains(numberToCheck);
+            if (mSensitiveNumbersMap.containsKey(networkMCC)) {
+                for (String num : mSensitiveNumbersMap.get(networkMCC)) {
+                    if (PhoneNumberUtils.compare(numberToCheck, num)) {
+                        return true;
+                    }
+                }
+            }
         }
         return false;
     }


### PR DESCRIPTION
* Currently, we just compare the strings for equality,
  which results in incorrect detection of sensitive nums
  a lot of the time, because adding (or removing) the
  country code is enough to make the detection fail,
  meaning the call to that phone number is logged
* Use Android's PhoneNumberUtils comparison method to
  fix this, since it takes these factors into account

Change-Id: I26ac180f8a6552cf87a4bada1d370f0ebb884ee1