### PR TITLE
Telecomm: Account for default data sub ID when setting MSIM audio params

### DIFF
--- a/src/com/android/server/telecom/CallAudioModeStateMachine.java
+++ b/src/com/android/server/telecom/CallAudioModeStateMachine.java
@@ -302,8 +302,10 @@ public class CallAudioModeStateMachine extends StateMachine {
             if (call != null && call.getTargetPhoneAccount() != null && setMsimAudioParams) {
                 PhoneAccountHandle handle = call.getTargetPhoneAccount();
                 PhoneAccount account = mTelecomManager.getPhoneAccount(handle);
+                int defaultDataSubId = SubscriptionManager.getDefaultDataSubscriptionId();
                 int subId = TelephonyManager.getDefault().getSubIdForPhoneAccount(account);
-                int phoneId = SubscriptionManager.getPhoneId(subId);
+                int phoneId = SubscriptionManager.getPhoneId(subId)
+                        ^ SubscriptionManager.getPhoneId(defaultDataSubId);
                 Log.d(LOG_TAG, "setAudioParameters phoneId=" + phoneId);
                 if (phoneId == 0) {
                     mAudioManager.setParameters("phone_type=cp1");


### PR DESCRIPTION
 * After all, the preferred SIM for mobile data also determines if
   audio routing must be switched. In case SIM2 is set to the
   preferred one, then the whole logic needs to be inverted.
   
 * This also addresses the edge case where in-call audio was broken
   while calling from SIM2 without any SIM card inserted in slot 0.
   Quite obviously, since default data SIM is automatically set to
   match the one and only inserted SIM card.

Change-Id: I72be3cf30d23b5993e5e54a48e377c8ad976d860