### PR TITLE
Proper supplementary service notification handling (3/5)

### DIFF
--- a/src/com/android/server/telecom/ParcelableCallUtils.java
+++ b/src/com/android/server/telecom/ParcelableCallUtils.java
@@ -339,7 +339,13 @@ public class ParcelableCallUtils {
         android.telecom.Call.Details.PROPERTY_SELF_MANAGED,
 
         Connection.PROPERTY_ASSISTED_DIALING_USED,
-        android.telecom.Call.Details.PROPERTY_ASSISTED_DIALING_USED
+        android.telecom.Call.Details.PROPERTY_ASSISTED_DIALING_USED,
+
+        Connection.PROPERTY_WAS_FORWARDED,
+        android.telecom.Call.Details.PROPERTY_WAS_FORWARDED,
+
+        Connection.PROPERTY_REMOTE_INCOMING_CALLS_BARRED,
+        android.telecom.Call.Details.PROPERTY_REMOTE_INCOMING_CALLS_BARRED
     };
 
     private static int convertConnectionToCallProperties(int connectionProperties) {


### PR DESCRIPTION
Pass parsed call properties around instead bleeding the implementation
detail 'Supplementary service notification' into all layers.

Change-Id: Ib7c3a494024013c261b1d708c47d0e80ae5876dd