### PR TITLE
Telecomm: Update MSIM audio params logic again

### DIFF
--- a/src/com/android/server/telecom/CallAudioModeStateMachine.java
+++ b/src/com/android/server/telecom/CallAudioModeStateMachine.java
@@ -314,10 +314,18 @@ public class CallAudioModeStateMachine extends StateMachine {
             if (setMsimAudioParams && call != null && call.getTargetPhoneAccount() != null) {
                 PhoneAccountHandle handle = call.getTargetPhoneAccount();
                 PhoneAccount account = mTelecomManager.getPhoneAccount(handle);
-                int defaultDataSubId = SubscriptionManager.getDefaultDataSubscriptionId();
-                int subId = TelephonyManager.getDefault().getSubIdForPhoneAccount(account);
-                int phoneId = SubscriptionManager.getPhoneId(subId)
-                        ^ SubscriptionManager.getPhoneId(defaultDataSubId);
+                TelephonyManager tm = TelephonyManager.getDefault();
+                boolean audioFollowDefaultSim = SystemProperties
+                        .getBoolean("ro.multisim.audio_follow_default_sim", true);
+                int subId = tm.getSubIdForPhoneAccount(account);
+                int phoneId = SubscriptionManager.getPhoneId(subId);
+
+                if (audioFollowDefaultSim ||
+                        tm.getSimState(0) != TelephonyManager.SIM_STATE_READY) {
+                    int defaultDataSubId = SubscriptionManager.getDefaultDataSubscriptionId();
+                    phoneId ^= SubscriptionManager.getPhoneId(defaultDataSubId);
+                }
+
                 Log.d(LOG_TAG, "setAudioParameters phoneId=" + phoneId);
                 if (phoneId == 0) {
                     mAudioManager.setParameters("phone_type=cp1");


### PR DESCRIPTION
* Change c0e6b1fd14b13fcc0b777c4e9fc10abfb6e042f1 updated the audio
  logic to track the preferred SIM, which is appropriate for most
  devices, but this inversion logic actually breaks audio routing
  on (some?) Samsung MSIM devices. The inversion logic is still
  required on such devices when SIM0 is not inserted/ready.
* Create a property to allow such devices to opt-out of the inversion
  logic.
* Test the state of SIM0 to make sure that the edge case is still
  handled.

Change-Id: Iec488433e2bed5c0109addfd3f934a4b18f146ff